### PR TITLE
[ADD] posts_controller.goの外部テスト作成

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /go/src/github.com/jigintern/Foodmates-server
 RUN go get -u github.com/gin-gonic/gin \
   && go get github.com/jinzhu/gorm \
   && go get github.com/go-sql-driver/mysql \
-  && go get github.com/joho/godotenv
+  && go get github.com/joho/godotenv \
+  && go get github.com/jigintern/Foodmates-server
 
 CMD ["go", "run", "main.go"]

--- a/controllers/friendships_controller.go
+++ b/controllers/friendships_controller.go
@@ -1,7 +1,7 @@
 package controllers
 
 import (
-	"../models"
+	"github.com/jigintern/Foodmates-server/models"
 	"fmt"
 	"github.com/gin-gonic/gin"
 	"github.com/jinzhu/gorm"

--- a/controllers/posts_controller.go
+++ b/controllers/posts_controller.go
@@ -1,7 +1,7 @@
 package controllers
 
 import (
-	"../models"
+	"github.com/jigintern/Foodmates-server/models"
 	"fmt"
 	"github.com/gin-gonic/gin"
 	"github.com/jinzhu/gorm"

--- a/controllers/users_controller.go
+++ b/controllers/users_controller.go
@@ -1,7 +1,7 @@
 package controllers
 
 import (
-	"../models"
+	"github.com/jigintern/Foodmates-server/models"
 	"github.com/gin-gonic/gin"
 	"strconv"
 	"time"

--- a/main.go
+++ b/main.go
@@ -7,8 +7,10 @@ import (
 
 	"log"
 	"errors"
-	"./models"
-	"./routers"
+//	"./models"
+	"github.com/jigintern/Foodmates-server/models"
+	"github.com/jigintern/Foodmates-server/routers"
+	//	"./routers"
 	"github.com/joho/godotenv"
 )
 
@@ -22,9 +24,20 @@ func EnvLoad() error {
 }
 
 func main() {
-	EnvLoad()
+	fmt.Printf("============= Started Foodmates-Server!! =============\n")
+	
+	err := EnvLoad()
+	if err != nil {
+		return
+	}
+	fmt.Printf("* .env loaded.\n")
+	
 	models.InitDB()
+	fmt.Printf("* Models initialized.\n")
+	
 	router := routers.InitRouter()
+	fmt.Printf("* Routers initialized.\n")
+	
 	server := &http.Server{
 		Addr:           fmt.Sprintf(":%d", 8080),
 		Handler:        router,
@@ -32,6 +45,7 @@ func main() {
 		WriteTimeout:   60 * time.Second,
 		MaxHeaderBytes: 1 << 20,
 	}
-
 	server.ListenAndServe()
+	fmt.Printf("* Now server is listening!!\n")
+	
 }

--- a/main.go
+++ b/main.go
@@ -4,18 +4,21 @@ import (
 	"fmt"
 	"net/http"
 	"time"
-	"log"
 
+	"log"
+	"errors"
 	"./models"
 	"./routers"
 	"github.com/joho/godotenv"
 )
 
-func EnvLoad() {
+func EnvLoad() error {
 	err := godotenv.Load()
 	if err != nil {
 		log.Fatal("Error loading .env file")
+		return errors.New("code must be hoge")
 	}
+	return nil
 }
 
 func main() {

--- a/models/gorm.go
+++ b/models/gorm.go
@@ -13,18 +13,20 @@ var db *gorm.DB
 func InitDB() {
 	USER := os.Getenv("MYSQL_USER")
 	PASS := os.Getenv("MYSQL_PASSWORD")
-	PROTOCOL := "tcp(t2.intern.jigd.info:3306)"
+	PROTOCOL := "tcp(mysql_host:3306)"
 	DBNAME := os.Getenv("MYSQL_DATABASE")
 
 	var err error
 	CONNECT := USER + ":" + PASS + "@" + PROTOCOL + "/" + DBNAME + "?charset=utf8&parseTime=True&loc=Local"
+	
+	fmt.Println("* Opening Mysql database...")
 	db, err = gorm.Open("mysql", CONNECT)
 
 	if err != nil {
 		panic(err.Error())
 	}
 
-	fmt.Printf("db_addr: %v\n", db)
+	fmt.Println("* Mysql database opened!!")
 	db.LogMode(true)
 }
 

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,7 @@
+# 外部テスト
+
+1. testディレクトリ以下に、*_test.goを作成する
+1. "testing"パッケージをimportする
+1. テストケースを記述する　この際、initializeパッケージのInitServer()を最初に実行する
+1. `sudo docker-compose up` でdockerコンテナを起動
+1. `sudo docker exec "foodmates-server_app_1" go test -v ./test/` でテスト実行

--- a/routers/routers.go
+++ b/routers/routers.go
@@ -1,7 +1,7 @@
 package routers
 
 import (
-	"../controllers"
+	"github.com/jigintern/Foodmates-server/controllers"
 	"github.com/gin-gonic/gin"
 )
 

--- a/test/controllers/posts_controller_test.go
+++ b/test/controllers/posts_controller_test.go
@@ -1,0 +1,58 @@
+package controllers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"fmt"
+
+	"../initialize"
+	"../../models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPostsSucceed(t *testing.T) {
+	router := initialize.InitServer()
+	
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/v1/posts/", nil)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, 200, w.Code)
+}
+
+func TestCreatePostSucceed(t *testing.T) {
+	jsonStr := `{"user_id:"` + "2" + `","dish_id":"` + "6" + `","comment":"` + "fafafafafafafafafa" + `","image_address":"` + "hahaha.png" + `"}`
+
+	req, err := http.NewRequest("POST", "http://localhost:8080/api/v1/posts/", bytes.NewBuffer([]byte(jsonStr)))
+	if err != nil {
+		t.Fatalf("generate request failed.")
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("send request failed.   %s", err.Error())
+	}
+	defer resp.Body.Close()
+
+	resbin, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read responce failed.")
+	}
+	var resjson models.Post
+	json.Unmarshal(resbin, resjson)
+	fmt.Println(resjson)
+}
+
+func TestCreatePostFailed(t *testing.T) {
+	router := initialize.InitServer()
+	
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/v1/posts/", nil)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, 400, w.Code)
+}

--- a/test/initialize/initialize.go
+++ b/test/initialize/initialize.go
@@ -1,0 +1,26 @@
+package initialize
+
+import (
+	"log"
+	"errors"
+
+	"../../routers"
+	"../../models"
+	"github.com/gin-gonic/gin"
+	"github.com/joho/godotenv"
+)
+
+func EnvLoad() error {
+	err := godotenv.Load("../../.env")
+	if err != nil {
+		log.Fatal("Error loading .env file")
+		return errors.New("code must be hoge")
+	}
+	return nil
+}
+
+func InitServer() *gin.Engine {
+	EnvLoad()
+	models.InitDB()
+	return routers.InitRouter()
+}

--- a/test/main_test.go
+++ b/test/main_test.go
@@ -1,0 +1,1 @@
+package main_test

--- a/test/routers/routers_test.go
+++ b/test/routers/routers_test.go
@@ -1,0 +1,19 @@
+package routers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"../initialize"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitRouter(t *testing.T) {
+	router := initialize.InitServer()
+	
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/v1/posts/", nil)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, 200, w.Code)
+}


### PR DESCRIPTION
- posts_controllerのReadPosts(), CreatePosts()に対し、失敗・成功のそれぞれのテストケースを作成
- テスト実行にあたり、テスト用にサーバー初期処理パッケージをtest/initializeに追加