### PR TITLE
[FIX] Readme.mdのテスト用コマンドの説明を修正

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,4 +4,4 @@
 1. "testing"パッケージをimportする
 1. テストケースを記述する　この際、initializeパッケージのInitServer()を最初に実行する
 1. `sudo docker-compose up` でdockerコンテナを起動
-1. `sudo docker exec "foodmates-server_app_1" go test -v ./test/` でテスト実行
+1. `sudo docker exec "foodmates-server_app_1" go test -v ./test/...` でテスト実行

--- a/readme.md
+++ b/readme.md
@@ -3,5 +3,5 @@
 1. testディレクトリ以下に、*_test.goを作成する
 1. "testing"パッケージをimportする
 1. テストケースを記述する　この際、initializeパッケージのInitServer()を最初に実行する
-1. `sudo docker-compose up` でdockerコンテナを起動
+1. `sudo docker-compose up --build` でdockerコンテナを起動
 1. `sudo docker exec "foodmates-server_app_1" go test -v ./test/...` でテスト実行


### PR DESCRIPTION
- パスの後に...を付けないと再帰的にテストが行われないらしいです