### PR TITLE
[FIX] CharacterSet of GORM Connection

### DIFF
--- a/models/gorm.go
+++ b/models/gorm.go
@@ -17,7 +17,7 @@ func InitDB() {
 	DBNAME := os.Getenv("MYSQL_DATABASE")
 
 	var err error
-	CONNECT := USER + ":" + PASS + "@" + PROTOCOL + "/" + DBNAME + "?charset=utf8&parseTime=True&loc=Local"
+	CONNECT := USER + ":" + PASS + "@" + PROTOCOL + "/" + DBNAME + "?charset=utf8mb4&parseTime=True&loc=Local"
 
 	fmt.Println("* Opening Mysql database...")
 	db, err = gorm.Open("mysql", CONNECT)


### PR DESCRIPTION
- Gormの接続時の文字コード設定がutf8になっていたのをutf8mb4に修正
- 初期データに含まれている絵文字がが正しくレコードに挿入できるように