### PR TITLE
[FIX] Routing of Read User's profile

### DIFF
--- a/controllers/users_controller.go
+++ b/controllers/users_controller.go
@@ -6,10 +6,35 @@ import (
 	"github.com/jigintern/Foodmates-server/models"
 	"log"
 	"net/http"
+	"strconv"
 )
 
-// ReadSpecificUser   GET "/api/v1/users/:id/"
-func ReadSpecificUser(ctx *gin.Context) {
+// ReadSpecificUser   GET "/api/v1/users/read/id/:id/"
+func ReadSpecificUserByID(ctx *gin.Context) {
+	ctx.Writer.Header().Set("Access-Control-Allow-Origin", "*")
+	id, err := strconv.Atoi(ctx.Param("id"))
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, nil)
+		return
+	}
+	var userData models.User
+	db, err := models.GetDB()
+
+	// DBがなければ500を返す
+	if err != nil {
+		ctx.JSON(http.StatusInternalServerError, gin.H{"status": http.StatusInternalServerError})
+		return
+	}
+	recordNotFound := db.Table("Users").Where("id = ?", id).First(&userData).RecordNotFound()
+	if recordNotFound {
+		ctx.JSON(http.StatusBadRequest, nil)
+	} else {
+		ctx.JSON(http.StatusOK, userData)
+	}
+}
+
+// ReadSpecificUser   GET "/api/v1/users/read/name/:login_name"
+func ReadSpecificUserByLoginName(ctx *gin.Context) {
 	ctx.Writer.Header().Set("Access-Control-Allow-Origin", "*")
 	loginName := ctx.Param("login_name")
 	var userData models.User

--- a/routers/routers.go
+++ b/routers/routers.go
@@ -44,8 +44,21 @@ func InitRouter() *gin.Engine {
 		}
 		users := api.Group("/users")
 		{
-			users.GET("/:login_name", controllers.ReadSpecificUser)
-			users.GET("/", controllers.ReadAllUsers)
+			readSpecificUser := users.Group("/read")
+			{
+				byID := readSpecificUser.Group("/id")
+				{
+					byID.GET("/:id", controllers.ReadSpecificUserByID)
+				}
+				byLoginName := readSpecificUser.Group("/name")
+				{
+					byLoginName.GET("/:login_name", controllers.ReadSpecificUserByLoginName)
+				}
+				allUsers := readSpecificUser.Group("/all")
+				{
+					allUsers.GET("/", controllers.ReadAllUsers)
+				}
+			}
 			createUser := users.Group("/signup")
 			{
 				createUser.POST("/", controllers.SignUp)


### PR DESCRIPTION
- ユーザー情報を取得するAPIに置いて、`id`と`login_name`の両方で取得できるようにし、それに応じてルーティングを変更
- 全てのユーザー情報を取得するAPIを`/api/v1/users/`から`/api/v1/users/read/all`に変更