### PR TITLE
[FIX] Docker Image Build Flow

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,15 +2,17 @@ version: '3'
 
 services:
   app:
-    build: .
+    build:
+      context: .
+      dockerfile: ./Dockerfile
     depends_on:
       - db
     ports:
       - "8080:8080"
-    command: bash -c 'go mod download && go run main.go'
     environment:
       PORT: "8080"
     tty: true
+    image: jigintern/foodmates_server
     volumes:
       - ".:/go/src/github.com/jigintern/Foodmates-server"
     restart: always


### PR DESCRIPTION
- ちょっとインターンの時に作ったDockerfileが気に食わなかったりしたので修正
  - サーバーをシングルバイナリで動くようにしてコンテナにいれるように
  - コンテナのダイエットに成功(当社比)

- イメージをビルドする時に.envを入れてしまっているので，dockerhubやらにpushはしない方がいいかも(イメージ名はjigintern/foodmates_server)(何かシークレットキーなどをいい感じに管理する方法があれば教えて欲しいです)